### PR TITLE
Add static assertion & remove `testing` feature

### DIFF
--- a/primitives/nomad/merkle/src/lib.rs
+++ b/primitives/nomad/merkle/src/lib.rs
@@ -20,6 +20,7 @@ pub mod proof;
 #[cfg(test)]
 pub(crate) mod test_utils;
 
+use frame_support::ensure;
 use sp_core::H256;
 
 /// Tree depth
@@ -29,7 +30,7 @@ pub type NomadLightMerkle = light::LightMerkle<TREE_DEPTH>;
 /// A Nomad protocol standard-depth proof
 pub type NomadProof = proof::Proof<TREE_DEPTH>;
 
-pub use error::*;
+pub use error::{TreeError, VerifyingError, VerifyingError::VerificationFailed};
 pub use light::*;
 pub use proof::*;
 pub use utils::*;
@@ -57,7 +58,7 @@ pub trait Merkle: core::fmt::Debug + Default {
 	type Proof: MerkleProof;
 
 	/// The maximum number of elements the tree can ingest
-	fn max_elements() -> Result<u32, TreeError>;
+	fn max_elements() -> u32;
 
 	/// The number of elements currently in the tree
 	fn count(&self) -> u32;
@@ -75,10 +76,8 @@ pub trait Merkle: core::fmt::Debug + Default {
 	fn verify(&self, proof: &Self::Proof) -> Result<(), VerifyingError> {
 		let actual = proof.root();
 		let expected = self.root();
-		if expected == actual {
-			Ok(())
-		} else {
-			Err(VerifyingError::VerificationFailed { expected, actual })
-		}
+		ensure!(expected == actual, VerificationFailed { expected, actual });
+
+		Ok(())
 	}
 }

--- a/primitives/nomad/merkle/src/light.rs
+++ b/primitives/nomad/merkle/src/light.rs
@@ -94,8 +94,6 @@ impl<const N: usize> Merkle for LightMerkle<N> {
 }
 
 impl<const N: usize> LightMerkle<N> {
-	pub const N_LESS_THAN_TREE_DEPTH_ASSERT: usize = TREE_DEPTH - N;
-
 	/// Instantiate a new tree with a known depth and a starting leaf-set
 	pub fn from_leaves(leaves: &[H256]) -> Result<Self, TreeError> {
 		let mut tree = Self::default();

--- a/primitives/nomad/merkle/src/utils.rs
+++ b/primitives/nomad/merkle/src/utils.rs
@@ -1,8 +1,5 @@
-use frame_support::ensure;
 use sp_core::H256;
 use tiny_keccak::{Hasher, Keccak};
-
-use crate::{TreeError, TREE_DEPTH};
 
 /// Return the keccak256 disgest of the concatenation of the arguments
 pub fn hash_concat(left: impl AsRef<[u8]>, right: impl AsRef<[u8]>) -> H256 {
@@ -12,18 +9,6 @@ pub fn hash_concat(left: impl AsRef<[u8]>, right: impl AsRef<[u8]>) -> H256 {
 	hasher.update(right.as_ref());
 	hasher.finalize(&mut output);
 	output.into()
-}
-
-/// Max number of leaves in a tree. Returns `None` if overflow occurred
-/// (i.e. n > 32).
-pub(crate) fn max_leaves(n: usize) -> Result<u32, TreeError> {
-	ensure!(n <= TREE_DEPTH, TreeError::DepthTooLarge);
-
-	Ok(if n == 32 {
-		u32::MAX
-	} else {
-		2u32.pow(n as u32) - 1
-	})
 }
 
 /// Compute a root hash from a leaf and a Merkle proof.

--- a/primitives/nomad/nomad-base/Cargo.toml
+++ b/primitives/nomad/nomad-base/Cargo.toml
@@ -20,22 +20,12 @@ tiny-keccak = { version = "2.0.2", default-features = false, features = ["keccak
 signature = { path = "../signature", default-features = false }
 
 nomad-core = { path = "../nomad-core", default-features = false }
+serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 
-[dependencies.serde]
-version = "1.0"
-default-features = false
-optional = true
-features = ["derive"]
+[dev-dependencies]
+ethers-signers = "0.13.0"
+once_cell = "1.8.0"
 
-[dependencies.ethers-signers]
-version = "0.13.0"
-default-features = false
-optional = true
-
-[dependencies.once_cell]
-version = "1.8.0"
-default-features = false
-optional = true
 
 [features]
 default = ["std"]
@@ -47,9 +37,4 @@ std = [
 	"frame-support/std",
 	"nomad-core/std"
 ]
-testing = [
-	"ethers-signers",
-	"once_cell",
-	"nomad-core/testing",
-	"signature/testing",
-]
+

--- a/primitives/nomad/nomad-base/src/lib.rs
+++ b/primitives/nomad/nomad-base/src/lib.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use signature::SignatureError;
 use sp_core::{H160, H256};
 
-#[cfg(feature = "testing")]
+#[cfg(test)]
 pub mod testing;
 
 #[derive(Clone, Copy, Encode, Decode, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
@@ -74,11 +74,9 @@ mod test {
 	use nomad_core::test_utils::Updater;
 
 	use super::*;
-	#[cfg(feature = "testing")]
 	use crate::testing::{FAKE_UPDATER, TEST_NOMAD_BASE, TEST_UPDATER, TEST_UPDATER_PRIVKEY};
 
 	#[test]
-	#[cfg(feature = "testing")]
 	fn it_accepts_valid_signature() {
 		let valid_signed = TEST_UPDATER.sign_update(H256::repeat_byte(0), H256::repeat_byte(1));
 		assert!(
@@ -88,7 +86,6 @@ mod test {
 	}
 
 	#[test]
-	#[cfg(feature = "testing")]
 	fn it_rejects_invalid_signature() {
 		let invalid_signed = FAKE_UPDATER.sign_update(H256::repeat_byte(0), H256::repeat_byte(1));
 		assert!(

--- a/primitives/nomad/nomad-base/src/testing.rs
+++ b/primitives/nomad/nomad-base/src/testing.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 use ethers_signers::LocalWallet;
 use nomad_core::test_utils::Updater;
 use once_cell::sync::Lazy;

--- a/primitives/nomad/nomad-core/Cargo.toml
+++ b/primitives/nomad/nomad-core/Cargo.toml
@@ -21,40 +21,23 @@ tiny-keccak = { version = "2.0.2", default-features = false, features = ["keccak
 signature = { path = "../signature", default-features = false }
 getrandom = { version = "0.2", default-features = false, features = ["js"] }
 
-[dependencies.serde]
-version = "1.0"
-default-features = false
-optional = true
-features = ["derive"]
+serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
+ethers-core = { version = "0.13.0", optional = true }
+ethers-signers = { version = "0.13.0", optional = true }
 
-[dependencies.ethers-signers]
-version = "0.13.0"
-default-features = false
-optional = true
-
-[dependencies.ethers-core]
-version = "0.13.0"
-default-features = false
-optional = true
-
-[dependencies.async-trait]
-version = "0.1.42"
-default-features = false
-optional = true
+[dev-dependencies]
+async-trait = "0.1.42"
 
 [features]
 default = ["std"]
 std = [
 	"serde",
+	"ethers-core",
+	"ethers-signers",
 	"primitive-types/serde",
 	"signature/std",
 	"codec/std",
 	"scale-info/std",
 	"frame-support/std",
 ]
-testing = [
-	"ethers-signers",
-	"ethers-core",
-	"async-trait",
-	"signature/testing"
-]
+

--- a/primitives/nomad/nomad-core/src/lib.rs
+++ b/primitives/nomad/nomad-core/src/lib.rs
@@ -19,5 +19,5 @@ pub use typed_message::*;
 mod utils;
 pub use utils::*;
 
-#[cfg(feature = "testing")]
+#[cfg(feature = "std")]
 pub mod test_utils;

--- a/primitives/nomad/nomad-core/src/update.rs
+++ b/primitives/nomad/nomad-core/src/update.rs
@@ -62,15 +62,13 @@ impl SignedUpdate {
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	#[cfg(feature = "testing")]
+	use super::H256;
 	use crate::test_utils::Updater;
 
 	pub const TEST_UPDATER_PRIVKEY: &str =
 		"1111111111111111111111111111111111111111111111111111111111111111";
 
 	#[test]
-	#[cfg(feature = "testing")]
 	fn recover_valid_update() {
 		use ethers_signers::{LocalWallet, Signer};
 

--- a/primitives/nomad/nomad-core/src/update_v2.rs
+++ b/primitives/nomad/nomad-core/src/update_v2.rs
@@ -57,15 +57,13 @@ impl SignedUpdateV2 {
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	#[cfg(feature = "testing")]
+	use super::H256;
 	use crate::test_utils::Updater;
 
 	pub const TEST_UPDATER_PRIVKEY: &str =
 		"1111111111111111111111111111111111111111111111111111111111111111";
 
 	#[test]
-	#[cfg(feature = "testing")]
 	fn recover_valid_update_v2() {
 		use ethers_signers::{LocalWallet, Signer};
 

--- a/primitives/nomad/signature/Cargo.toml
+++ b/primitives/nomad/signature/Cargo.toml
@@ -41,21 +41,11 @@ thiserror-no-std = "2.0.1"
 hex = { version = "0.4.3", default-features = false }
 once_cell = { version = "1.12.0", optional = true }
 
-[dependencies.serde]
-version = "1.0"
-default-features = false
-optional = true
-features = ["derive"]
+serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
+ethers-core = { version = "0.13.0", optional = true }
 
-[dependencies.ethers-core]
-version = "0.13.0"
-default-features = false
-optional = true
-
-[dependencies.byte-slice-cast]
-version  = "1.2.1"
-default-features = false
-optional = true
+[dev-dependencies]
+byte-slice-cast = "1.2.1"
 
 [features]
 default = ["std"]
@@ -65,5 +55,5 @@ std = [
 	"codec/std",
 	"scale-info/std",
 	"frame-support/std",
+	"ethers-core"
 ]
-testing = ["ethers-core", "byte-slice-cast"]

--- a/primitives/nomad/signature/src/signature.rs
+++ b/primitives/nomad/signature/src/signature.rs
@@ -239,8 +239,8 @@ impl From<H256> for RecoveryMessage {
 	fn from(hash: H256) -> Self { RecoveryMessage::Hash(hash) }
 }
 
+#[cfg(feature = "std")]
 // Want to convert ethers signature into our no-std version in tests
-#[cfg(feature = "testing")]
 impl From<ethers_core::types::Signature> for Signature {
 	fn from(sig: ethers_core::types::Signature) -> Self {
 		// ethers-core 0.13.0 uses primitive types 0.11.1, sp-core 4.0.0-dev


### PR DESCRIPTION
It removes the `testing` feature and release on standards like `std` feature & `#[cfg(test)]`.
It also uses a **static assertion** to double-check  `N <= TREE_DEPTH` 